### PR TITLE
Fix bugs writing out variables

### DIFF
--- a/BTagTrainingPreprocessing/src/BTagJetWriter.cxx
+++ b/BTagTrainingPreprocessing/src/BTagJetWriter.cxx
@@ -1,11 +1,11 @@
 #include "BTagJetWriter.hh"
-#include "BTagWriterConfig.hh"
+#include "BTagJetWriterConfig.hh"
 #include "HdfTuple.hh"
 
 
 BTagJetWriter::BTagJetWriter(
   H5::CommonFG& output_file,
-  const BTagWriterConfig& config)
+  const BTagJetWriterConfig& config)
 {
 
   // create the variable fillers
@@ -16,6 +16,7 @@ BTagJetWriter::BTagJetWriter(
   add_btag_fillers<double, float>(fillers, config.double_variables);
   add_btag_fillers<float>(fillers, config.float_variables);
   add_btag_fillers<int>(fillers, config.int_variables);
+  add_truth_labels(fillers, config.truth_labels);
 
   // some things like 4 momenta have to be hand coded
   std::function<float(void)> pt = [this]() {
@@ -51,5 +52,15 @@ void BTagJetWriter::add_btag_fillers(VariableFillers& vars,
       return this->m_current_jet->btagging()->auxdata<I>(btag_var);
     };
     vars.add(btag_var, filler);
+  }
+}
+
+void BTagJetWriter::add_truth_labels(VariableFillers& vars,
+                                     const std::vector<std::string>& names) {
+  for (const auto& label: names) {
+    std::function<int(void)> filler = [this, label]() {
+      return this->m_current_jet->auxdata<int>(label);
+    };
+    vars.add(label, filler);
   }
 }

--- a/BTagTrainingPreprocessing/src/BTagJetWriter.hh
+++ b/BTagTrainingPreprocessing/src/BTagJetWriter.hh
@@ -14,14 +14,14 @@
 #include <string>
 #include <vector>
 
-class BTagWriterConfig;
+class BTagJetWriterConfig;
 
 class BTagJetWriter
 {
 public:
   BTagJetWriter(
     H5::CommonFG& output_file,
-    const BTagWriterConfig&);
+    const BTagJetWriterConfig& jet);
   ~BTagJetWriter();
   BTagJetWriter(BTagJetWriter&) = delete;
   BTagJetWriter operator=(BTagJetWriter&) = delete;
@@ -29,6 +29,7 @@ public:
 private:
   template<typename I, typename O = I>
   void add_btag_fillers(VariableFillers&, const std::vector<std::string>&);
+  void add_truth_labels(VariableFillers&, const std::vector<std::string>&);
   const xAOD::Jet* m_current_jet;
   WriterXd* m_hdf5_jet_writer;
 };

--- a/BTagTrainingPreprocessing/src/BTagJetWriterConfig.hh
+++ b/BTagTrainingPreprocessing/src/BTagJetWriterConfig.hh
@@ -1,0 +1,16 @@
+#ifndef BTAG_JET_WRITER_CONFIG_HH
+#define BTAG_JET_WRITER_CONFIG_HH
+
+#include <vector>
+#include <string>
+
+struct BTagJetWriterConfig {
+  std::vector<std::string> double_variables;
+  std::vector<std::string> float_variables;
+  std::vector<std::string> int_variables;
+  std::vector<std::string> truth_labels;
+  std::string name;
+};
+
+
+#endif

--- a/BTagTrainingPreprocessing/src/BTagTrackWriter.cxx
+++ b/BTagTrainingPreprocessing/src/BTagTrackWriter.cxx
@@ -1,5 +1,5 @@
 #include "BTagTrackWriter.hh"
-#include "BTagWriterConfig.hh"
+#include "BTagTrackWriterConfig.hh"
 #include "HdfTuple.hh"
 
 // Less Standard Libraries (for atlas)
@@ -10,7 +10,7 @@
 
 BTagTrackWriter::BTagTrackWriter(
   H5::CommonFG& output_file,
-  const BTagWriterConfig& config):
+  const BTagTrackWriterConfig& config):
   m_current_tracks()
 {
 

--- a/BTagTrainingPreprocessing/src/BTagTrackWriter.hh
+++ b/BTagTrainingPreprocessing/src/BTagTrackWriter.hh
@@ -14,7 +14,7 @@ namespace xAOD {
 }
 
 class VariableFillers;
-class BTagWriterConfig;
+class BTagTrackWriterConfig;
 class WriterXd;
 
 class BTagTrackWriter
@@ -23,7 +23,7 @@ public:
   typedef std::vector<const xAOD::TrackParticle*> Tracks;
   BTagTrackWriter(
     H5::CommonFG& output_file,
-    const BTagWriterConfig&);
+    const BTagTrackWriterConfig&);
   ~BTagTrackWriter();
   BTagTrackWriter(BTagTrackWriter&) = delete;
   BTagTrackWriter operator=(BTagTrackWriter&) = delete;

--- a/BTagTrainingPreprocessing/src/BTagTrackWriterConfig.hh
+++ b/BTagTrainingPreprocessing/src/BTagTrackWriterConfig.hh
@@ -1,10 +1,10 @@
-#ifndef BTAG_WRITER_CONFIG_HH
-#define BTAG_WRITER_CONFIG_HH
+#ifndef BTAG_TRACK_WRITER_CONFIG_HH
+#define BTAG_TRACK_WRITER_CONFIG_HH
 
 #include <vector>
 #include <string>
 
-struct BTagWriterConfig {
+struct BTagTrackWriterConfig {
   std::vector<std::string> double_variables;
   std::vector<std::string> float_variables;
   std::vector<std::string> int_variables;

--- a/BTagTrainingPreprocessing/utils/dump-test.cxx
+++ b/BTagTrainingPreprocessing/utils/dump-test.cxx
@@ -10,7 +10,8 @@
 #include "Jet.hh"
 
 // new way to do local things
-#include "BTagWriterConfig.hh"
+#include "BTagTrackWriterConfig.hh"
+#include "BTagJetWriterConfig.hh"
 #include "BTagJetWriter.hh"
 #include "BTagTrackWriter.hh"
 
@@ -85,16 +86,31 @@ int main (int argc, char *argv[])
 	// new way to do output files
 	H5::H5File output("output.h5", H5F_ACC_TRUNC);
 	// set up jet writer
-	BTagWriterConfig jet_cfg;
-	jet_cfg.double_variables = {"pt", "eta", "MV2c10_discriminant", "IP2D_pb", "IP2D_pc", "IP2D_pu", "IP3D_pb", "IP3D_pc", "IP3D_pu", "SV1_pu", "SV1_pb", "SV1_pc", "rnnip_pu", "rnnip_pc", "rnnip_pb", "rnnip_ptau"};
-	jet_cfg.float_variables = {"JetFitter_energyFraction", "JetFitter_mass", "JetFitter_significance3d", "JetFitter_deltaphi", "JetFitter_deltaeta", "JetFitter_massUncorr", "JetFitter_dRFlightDir", "SV1_masssvx", "SV1_efracsvx", "SV1_significance3d", "SV1_dstToMatLay", "SV1_deltaR", "SV1_Lxy", "SV1_L3d"};
-	jet_cfg.int_variables = {"JetFitter_nVTX", "JetFitter_nSingleTracks", "JetFitter_nTracksAtVtx", "JetFitter_N2Tpair", "SV1_N2Tpair", "SV1_NGTinSvx", "PartonTruthLabelID", "HadronConeExclTruthLabelID"};
+	BTagJetWriterConfig jet_cfg;
+	jet_cfg.double_variables = {
+    "MV2c10_discriminant",
+    "IP2D_pb", "IP2D_pc", "IP2D_pu",
+    "IP3D_pb", "IP3D_pc", "IP3D_pu",
+    "SV1_pu", "SV1_pb", "SV1_pc",
+    "rnnip_pu", "rnnip_pc", "rnnip_pb", "rnnip_ptau"};
+	jet_cfg.float_variables = {
+    "JetFitter_energyFraction", "JetFitter_mass",
+    "JetFitter_significance3d", "JetFitter_deltaphi", "JetFitter_deltaeta",
+    "JetFitter_massUncorr", "JetFitter_dRFlightDir",
+    "SV1_masssvx", "SV1_efracsvx", "SV1_significance3d", "SV1_dstToMatLay",
+    "SV1_deltaR", "SV1_Lxy", "SV1_L3d"};
+	jet_cfg.int_variables = {
+    "JetFitter_nVTX", "JetFitter_nSingleTracks", "JetFitter_nTracksAtVtx",
+    "JetFitter_N2Tpair",
+    "SV1_N2Tpair", "SV1_NGTinSvx"};
+  jet_cfg.truth_labels = {
+    "PartonTruthLabelID",
+    "HadronConeExclTruthLabelID"};
 	jet_cfg.name = "jets";
 	BTagJetWriter jet_writer(output, jet_cfg);
 	// set up track writer
-	BTagWriterConfig track_cfg;
+	BTagTrackWriterConfig track_cfg;
 	track_cfg.name = "tracks";
-	track_cfg.double_variables = {"pt", "eta"};
 	track_cfg.float_variables = {"chiSquared", "d0"};
 	track_cfg.output_size = {10};
 	BTagTrackWriter track_writer(output, track_cfg);


### PR DESCRIPTION
There were two problems with the code:

 - pt and eta were defined in the list of output
   variables. Unfortunately these (like all 4 momentum variables)
   can't be accessed via the normal string accessors and are hard
   coded instead in the writers. Defining them in both places throws
   an exception when HDF5 tries to add the same variable twice.

 - We were trying to read truth labels out of the b-tagging container
   in the jet. These are actually jet attributes, so accessing them is
   slightly different.

I also split the config structures into one for tracks and another one
for jets. Given that some of the fields only make sense in one case
(i.e. truth labels in the jet case, length in the track case) using
the same struct for both was a hack anyway.